### PR TITLE
공통컴포넌트 memo

### DIFF
--- a/src/components/fallback/ErrorPage.tsx
+++ b/src/components/fallback/ErrorPage.tsx
@@ -1,5 +1,6 @@
 import vitddory from "@assets/images/vitddory.png";
-import RootLayout from "layouts/RootLayout";
+import Footer from "@components/ui/footer/Footer";
+import Header from "@components/ui/header/Header";
 import { Link } from "react-router-dom";
 import styled from "styled-components";
 
@@ -40,14 +41,16 @@ const MoveBtn = styled(Link)`
 
 const ErrorPage = () => {
   return (
-    <RootLayout>
+    <>
+      <Header />
       <ErrorPageContainer>
         <img src={vitddory} />
         <h1>ERROR</h1>
         <p>PAGE NOT FOUND</p>
         <MoveBtn to="/">홈으로</MoveBtn>
       </ErrorPageContainer>
-    </RootLayout>
+      <Footer />
+    </>
   );
 };
 

--- a/src/components/ui/footer/Footer.tsx
+++ b/src/components/ui/footer/Footer.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "styled-components";
 import Information from "./Information";
 import Logo from "./Logo";
@@ -64,4 +63,4 @@ const Footer = () => {
     </FooterStyle>
   );
 };
-export default React.memo(Footer);
+export default Footer;

--- a/src/components/ui/footer/Logo.tsx
+++ b/src/components/ui/footer/Logo.tsx
@@ -1,5 +1,4 @@
 import footerLogo from "@assets/images/footerLogo.svg";
-import React from "react";
 import styled from "styled-components";
 
 const FooterLogoStyle = styled.h2`
@@ -15,4 +14,4 @@ const Logo = () => {
     </FooterLogoStyle>
   );
 };
-export default React.memo(Logo);
+export default Logo;

--- a/src/components/ui/footer/Nav.tsx
+++ b/src/components/ui/footer/Nav.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import styled from "styled-components";
 
 const FooterNavStyle = styled.ul`
@@ -28,4 +27,4 @@ const Nav = () => {
     </FooterNavStyle>
   );
 };
-export default React.memo(Nav);
+export default Nav;

--- a/src/components/ui/footer/Select.tsx
+++ b/src/components/ui/footer/Select.tsx
@@ -110,4 +110,4 @@ const Select = () => {
     </SelectStyle>
   );
 };
-export default React.memo(Select);
+export default Select;

--- a/src/components/ui/footer/Social.tsx
+++ b/src/components/ui/footer/Social.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { FaFigma, FaGithub } from "react-icons/fa";
 import { RiNotionFill } from "react-icons/ri";
 import { Link } from "react-router-dom";
@@ -43,7 +42,6 @@ const Social = () => {
       icon: <RiNotionFill />,
     },
   ];
-
   return (
     <SocialStyle>
       {socialList.map((social, index) => (
@@ -56,4 +54,4 @@ const Social = () => {
     </SocialStyle>
   );
 };
-export default React.memo(Social);
+export default Social;

--- a/src/components/ui/header/Header.tsx
+++ b/src/components/ui/header/Header.tsx
@@ -1,12 +1,12 @@
 import useDetectScroll from "hooks/useDetectScroll";
-import React, { useState } from "react";
+import { useCallback, useState } from "react";
 import { useLocation } from "react-router-dom";
 import styled from "styled-components";
 import Nav from "./gnb/Nav";
 import Logo from "./Logo";
 import Utils from "./Utils";
 
-const HeaderStyle = styled.header<{ $isShowNav: boolean; $path: string; $scrollHeight: number }>`
+const HeaderStyle = styled.header<{ $isShowNav: boolean; $path: string; $scrollHeight: boolean }>`
   position: fixed;
   top: 0;
   left: 0;
@@ -18,7 +18,7 @@ const HeaderStyle = styled.header<{ $isShowNav: boolean; $path: string; $scrollH
   z-index: 2;
   overflow: hidden;
   background-color: ${(props) =>
-    props.$isShowNav ? "#fff" : props.$path !== "/" ? "#000" : props.$scrollHeight > 100 ? "#000" : "transparent"};
+    props.$isShowNav ? "#fff" : props.$path !== "/" ? "#000" : props.$scrollHeight ? "#000" : "transparent"};
   transition:
     height 0.25s ease-in,
     background-color 0.25s ease-out;
@@ -45,20 +45,20 @@ const HeaderInnerStyle = styled.div<{ $isShowNav: boolean }>`
 const Header = () => {
   const $path = useLocation().pathname;
   const [$isShowNav, setIsShowNav] = useState(false);
-  const { $scrollHeight } = useDetectScroll();
+  const $scrollHeight = useDetectScroll();
 
-  const onMouseOverHandler = () => {
+  const onMouseEnterHandler = useCallback(() => {
     setIsShowNav(true);
-  };
+  }, []);
 
-  const onMouseOutHandler = () => {
+  const onMouseLeaveHandler = useCallback(() => {
     setIsShowNav(false);
-  };
+  }, []);
 
   return (
     <HeaderStyle
-      onMouseOver={onMouseOverHandler}
-      onMouseOut={onMouseOutHandler}
+      onMouseEnter={onMouseEnterHandler}
+      onMouseLeave={onMouseLeaveHandler}
       $isShowNav={$isShowNav}
       $path={$path}
       $scrollHeight={$scrollHeight}>
@@ -71,4 +71,6 @@ const Header = () => {
   );
 };
 
-export default React.memo(Header);
+export default Header;
+
+//

--- a/src/hooks/useDetectScroll.tsx
+++ b/src/hooks/useDetectScroll.tsx
@@ -1,43 +1,22 @@
-import { useCallback, useEffect, useState } from "react";
+import { useEffect, useState } from "react";
 
 const useDetectScroll = () => {
-  const [$scrollHeight, setScrollHeight] = useState(0);
-
-  const throttle = useCallback((callback: () => void, delay: number) => {
-    let lastCall = 0;
-    return () => {
-      const now = new Date().getTime();
-      if (now - lastCall >= delay) {
-        lastCall = now;
-        callback();
-      }
-    };
-  }, []);
-
-  const debounce = useCallback((callback: () => void, delay: number) => {
-    let timeoutId: NodeJS.Timeout;
-    return () => {
-      clearTimeout(timeoutId);
-      timeoutId = setTimeout(() => {
-        callback();
-      }, delay);
-    };
-  }, []);
+  const [isScrolled, setIsScrolled] = useState(false);
 
   useEffect(() => {
-    const scrollHandler = throttle(() => {
-      const scrollPosition = window.scrollY;
-      if (scrollPosition !== $scrollHeight) setScrollHeight(scrollPosition);
-    }, 100);
+    const handleScroll = () => {
+      const currentScrollY = window.scrollY;
 
-    const debouncedScrollHandler = debounce(scrollHandler, 10);
-
-    window.addEventListener("scroll", debouncedScrollHandler);
-    return (): void => {
-      window.removeEventListener("scroll", debouncedScrollHandler);
+      setIsScrolled(currentScrollY > 100);
     };
-  }, [$scrollHeight, throttle]);
 
-  return { $scrollHeight };
+    window.addEventListener("scroll", handleScroll);
+
+    return () => {
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, []);
+
+  return isScrolled;
 };
 export default useDetectScroll;

--- a/src/layouts/RootLayout.tsx
+++ b/src/layouts/RootLayout.tsx
@@ -1,8 +1,7 @@
 import ScrollToTop from "@components/ScrollToTop";
 import Footer from "@components/ui/footer/Footer";
 import Header from "@components/ui/header/Header";
-import { ReactNode } from "react";
-import { Outlet, useRouteError } from "react-router-dom";
+import { Outlet } from "react-router-dom";
 import styled from "styled-components";
 
 const BasicLayoutStyle = styled.div`
@@ -12,16 +11,15 @@ const BasicLayoutStyle = styled.div`
   justify-content: center;
   align-items: center;
 `;
-const RootLayout = ({ children }: { children?: ReactNode }) => {
-  const error = useRouteError();
-
+const RootLayout = () => {
   return (
     <BasicLayoutStyle>
       <ScrollToTop />
       <Header />
-      {error ? children : <Outlet />}
+      <Outlet />
       <Footer />
     </BasicLayoutStyle>
   );
 };
+
 export default RootLayout;


### PR DESCRIPTION
## 📝 작업 내용
1. useRouteError()훅이 무조건 렌더링되게 만들어서 error페이지 분리
2. root는 상태가 없어 렌더링되지않기때문에 하위 컴포넌트 memo삭제
3. header는 상태 3가지가 자주 변하기 때문에 하위 컴포넌트, 함수 모두 memo
4. scroll정보는 100이상일때만 확인하고 있기때문에 100이상인지 아닌지 판단하는 훅으로 변경

## 이후 작업
1. 하위페이지 memo
